### PR TITLE
added compatibility for special characters in rclone remote

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -94,7 +94,7 @@ function upload() {
         exit 1
     fi
 
-    rclone copy ${UPLOAD_FILE} ${RCLONE_REMOTE}
+    rclone copy ${UPLOAD_FILE} "${RCLONE_REMOTE}"
     if [[ $? != 0 ]]; then
         color red "upload failed"
 
@@ -108,13 +108,13 @@ function clear_history() {
     if [[ "${BACKUP_KEEP_DAYS}" -gt 0 ]]; then
         color blue "delete ${BACKUP_KEEP_DAYS} days ago backup files"
 
-        local RCLONE_DELETE_LIST=$(rclone lsf ${RCLONE_REMOTE} | head -n -${BACKUP_KEEP_DAYS})
+        local RCLONE_DELETE_LIST=$(rclone lsf "${RCLONE_REMOTE}" | head -n -${BACKUP_KEEP_DAYS})
 
         for RCLONE_DELETE_FILE in ${RCLONE_DELETE_LIST}
         do
             color yellow "deleting ${RCLONE_DELETE_FILE}"
 
-            rclone delete ${RCLONE_REMOTE}/${RCLONE_DELETE_FILE}
+            rclone delete "${RCLONE_REMOTE}/${RCLONE_DELETE_FILE}"
             if [[ $? != 0 ]]; then
                 color red "delete ${RCLONE_DELETE_FILE} failed"
             fi

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -33,7 +33,7 @@ function color() {
 #     None
 ########################################
 function check_rclone_connection() {
-    rclone mkdir ${RCLONE_REMOTE}
+    rclone mkdir "${RCLONE_REMOTE}"
     if [[ $? != 0 ]]; then
         color red "storage system connection failure"
         exit 1


### PR DESCRIPTION
After setting up I've encountered a problem because by rclone remote contained a space. 

Log:
```
Starting bitwarden_backup_1 ... done
Attaching to bitwarden_backup_1
backup_1     | ========================================
backup_1     | CRON: 55 * * * *
backup_1     | RCLONE_REMOTE_NAME: Google Drive
backup_1     | RCLONE_REMOTE_DIR: /
backup_1     | RCLONE_REMOTE: Google Drive:/
backup_1     | ZIP_ENABLE: TRUE
backup_1     | ZIP_PASSWORD: X Chars
backup_1     | BACKUP_KEEP_DAYS: 7
backup_1     | MAIL_SMTP_ENABLE: TRUE
backup_1     | MAIL_TO: XXX
backup_1     | MAIL_WHEN_SUCCESS: TRUE
backup_1     | MAIL_WHEN_FAILURE: TRUE
backup_1     | TIMEZONE: Europe/Berlin
backup_1     | ========================================
backup_1     | Usage:
backup_1     |   rclone mkdir remote:path [flags]
backup_1     | 
backup_1     | Flags:
backup_1     |   -h, --help   help for mkdir
backup_1     | 
backup_1     | Use "rclone [command] --help" for more information about a command.
backup_1     | Use "rclone help flags" for to see the global flags.
backup_1     | Use "rclone help backends" for a list of supported services.
backup_1     | Command mkdir needs 1 arguments maximum: you provided 2 non flag arguments: ["Google" "Drive:/"]
backup_1     | storage system connection failure
```

I've escaped all calls of `RCLONE_REMOTE`. This should do the trick. I didn't test it tho.