### PR TITLE
added current time and timezone to backup files

### DIFF
--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -2,15 +2,15 @@
 
 . /app/includes.sh
 
-TODAY=$(date +%Y%m%d)
+NOW=$(date +"%Y%m%d-%H%M%S%Z")
 # backup bitwarden_rs database file
-BACKUP_FILE_DB="${BACKUP_DIR}/db.${TODAY}.sqlite3"
+BACKUP_FILE_DB="${BACKUP_DIR}/db.${NOW}.sqlite3"
 # backup bitwarden_rs config file
-BACKUP_FILE_CONFIG="${BACKUP_DIR}/config.${TODAY}.json"
+BACKUP_FILE_CONFIG="${BACKUP_DIR}/config.${NOW}.json"
 # backup bitwarden_rs attachments directory
-BACKUP_FILE_ATTACHMENTS="${BACKUP_DIR}/attachments.${TODAY}.tar"
+BACKUP_FILE_ATTACHMENTS="${BACKUP_DIR}/attachments.${NOW}.tar"
 # backup zip file
-BACKUP_FILE_ZIP="${BACKUP_DIR}/backup.${TODAY}.zip"
+BACKUP_FILE_ZIP="${BACKUP_DIR}/backup.${NOW}.zip"
 
 function clear_dir() {
     rm -rf ${BACKUP_DIR}

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -108,7 +108,7 @@ function clear_history() {
     if [[ "${BACKUP_KEEP_DAYS}" -gt 0 ]]; then
         color blue "delete ${BACKUP_KEEP_DAYS} days ago backup files"
 
-        local RCLONE_DELETE_LIST=$(rclone lsf "${RCLONE_REMOTE}" | head -n -${BACKUP_KEEP_DAYS})
+        local RCLONE_DELETE_LIST=$(rclone lsf "${RCLONE_REMOTE}" --min-age ${BACKUP_KEEP_DAYS}d)
 
         for RCLONE_DELETE_FILE in ${RCLONE_DELETE_LIST}
         do


### PR DESCRIPTION
My cronjob is set to every 6 hours. Because the backup file only contains the current date rclone overrides my backups. This is not wanted. 
Therefore I added the current time and timezone to the backup files, so that each backup filename is unique.
