### PR TITLE
escaped every parameter in all scripts

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ LABEL "repository"="https://github.com/ttionya/BitwardenRS-Backup" \
 COPY scripts/*.sh /app/
 
 RUN chmod +x /app/*.sh \
-  && apk add --no-cache sqlite zip heirloom-mailx tzdata
+  && apk add --no-cache bash sqlite zip heirloom-mailx tzdata
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ Default: `0`
 #### BACKUP_FILE_DATE_SUFFIX
 
 Each backup file is suffixed by default with `%Y%m%d`. If you back up your vault multiple times a day that suffix is not unique anymore.
-This environment variable allows you to append that date (`%Y%m%d${BACKUP_FILE_DATE_SUFFIX`) suffix in order to create a unique backup name. 
+This environment variable allows you to append that date (`%Y%m%d${BACKUP_FILE_DATE_SUFFIX}`) suffix in order to create a unique backup name. 
 
 Please use the [date man page](https://man7.org/linux/man-pages/man1/date.1.html) for the format notation.
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -192,7 +192,7 @@ Rclone 远程名称，你可以自己修改命名。
 
 #### BACKUP_FILE_DATE_SUFFIX
 
-每个备份文件都默认添加 `%Y%m%d` 后缀。如果你在一天内多次进行备份，每次备份都会被覆盖之前同名的文件。这个环境变量允许你追加日期信息 (`%Y%m%d${BACKUP_FILE_DATE_SUFFIX`) 以便每次备份生成不同的文件。
+每个备份文件都默认添加 `%Y%m%d` 后缀。如果你在一天内多次进行备份，每次备份都会被覆盖之前同名的文件。这个环境变量允许你追加日期信息 (`%Y%m%d${BACKUP_FILE_DATE_SUFFIX}`) 以便每次备份生成不同的文件。
 
 在 [这里](https://man7.org/linux/man-pages/man1/date.1.html) 查看时间格式化说明。
 

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -1,9 +1,9 @@
-#!/bin/sh
+#!/bin/bash
 
 . /app/includes.sh
 
 function clear_dir() {
-    rm -rf ${BACKUP_DIR}
+    rm -rf "${BACKUP_DIR}"
 }
 
 function backup_init() {
@@ -22,7 +22,7 @@ function backup_db() {
     color blue "backup bitwarden_rs sqlite database"
 
     if [[ -f "${DATA_DB}" ]]; then
-        sqlite3 ${DATA_DB} ".backup ${BACKUP_FILE_DB}"
+        sqlite3 "${DATA_DB}" ".backup ${BACKUP_FILE_DB}"
     else
         color yellow "not found bitwarden_rs sqlite database, skipping"
     fi
@@ -44,24 +44,24 @@ function backup_attachments() {
     local DATA_ATTACHMENTS="attachments"
 
     if [[ -d "${DATA_DIR}/${DATA_ATTACHMENTS}" ]]; then
-        tar -c -C ${DATA_DIR} -f ${BACKUP_FILE_ATTACHMENTS} ${DATA_ATTACHMENTS}
+        tar -c -C "${DATA_DIR}" -f "${BACKUP_FILE_ATTACHMENTS}" "${DATA_ATTACHMENTS}"
 
         color blue "display attachments tar file list"
 
-        tar -tf ${BACKUP_FILE_ATTACHMENTS}
+        tar -tf "${BACKUP_FILE_ATTACHMENTS}"
     else
         color yellow "not found bitwarden_rs attachments directory, skipping"
     fi
 }
 
 function backup() {
-    mkdir -p ${BACKUP_DIR}
+    mkdir -p "${BACKUP_DIR}"
 
     backup_db
     backup_config
     backup_attachments
 
-    ls -lah ${BACKUP_DIR}
+    ls -lah "${BACKUP_DIR}"
 }
 
 function backup_package() {
@@ -70,13 +70,13 @@ function backup_package() {
 
         UPLOAD_FILE="${BACKUP_FILE_ZIP}"
 
-        zip -jP ${ZIP_PASSWORD} ${BACKUP_FILE_ZIP} ${BACKUP_DIR}/*
+        zip -jP "${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}/*"
 
-        ls -lah ${BACKUP_DIR}
+        ls -lah "${BACKUP_DIR}"
 
         color blue "display backup zip file list"
 
-        zip -sf ${BACKUP_FILE_ZIP}
+        zip -sf "${BACKUP_FILE_ZIP}"
     else
         color yellow "skip package backup files"
 
@@ -88,7 +88,7 @@ function upload() {
     color blue "upload backup file to storage system"
 
     # upload file not exist
-    if [[ ! -f ${UPLOAD_FILE} ]]; then
+    if [[ ! -f "${UPLOAD_FILE}" ]]; then
         color red "upload file not found"
 
         send_mail_content "FALSE" "File upload failed at $(date +"%Y-%m-%d %H:%M:%S %Z"). Reason: Upload file not found."
@@ -96,7 +96,7 @@ function upload() {
         exit 1
     fi
 
-    rclone copy ${UPLOAD_FILE} "${RCLONE_REMOTE}"
+    rclone copy "${UPLOAD_FILE}" "${RCLONE_REMOTE}"
     if [[ $? != 0 ]]; then
         color red "upload failed"
 
@@ -110,9 +110,9 @@ function clear_history() {
     if [[ "${BACKUP_KEEP_DAYS}" -gt 0 ]]; then
         color blue "delete ${BACKUP_KEEP_DAYS} days ago backup files"
 
-        local RCLONE_DELETE_LIST=$(rclone lsf "${RCLONE_REMOTE}" --min-age ${BACKUP_KEEP_DAYS}d)
+        local RCLONE_DELETE_LIST=($(rclone lsf "${RCLONE_REMOTE}" --min-age ${BACKUP_KEEP_DAYS}d))
 
-        for RCLONE_DELETE_FILE in ${RCLONE_DELETE_LIST}
+        for RCLONE_DELETE_FILE in "${RCLONE_DELETE_LIST[@]}"
         do
             color yellow "deleting ${RCLONE_DELETE_FILE}"
 

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /app/includes.sh
 
@@ -37,7 +37,7 @@ fi
 
 function configure_timezone() {
     if [[ ! -f /etc/localtime || ! -f /etc/timezone ]]; then
-        cp -f /usr/share/zoneinfo/${TIMEZONE} /etc/localtime
+        cp -f "/usr/share/zoneinfo/${TIMEZONE}" /etc/localtime
         echo "${TIMEZONE}" > /etc/timezone
     fi
 }

--- a/scripts/includes.sh
+++ b/scripts/includes.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 DATA_DIR="/bitwarden/data"
 DATA_DB="${DATA_DIR}/db.sqlite3"
@@ -53,7 +53,7 @@ function send_mail() {
         local MAIL_VERBOSE="-v"
     fi
 
-    echo "$2" | mailx ${MAIL_VERBOSE} -s "$1" ${MAIL_SMTP_VARIABLES} ${MAIL_TO}
+    echo "$2" | mailx "${MAIL_VERBOSE}" -s "$1" ${MAIL_SMTP_VARIABLES} "${MAIL_TO}"
     if [[ $? != 0 ]]; then
         color red "mail sending failed"
     else

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 . /app/includes.sh
 
@@ -9,7 +9,7 @@ RESTORE_FILE_ZIP=""
 ZIP_PASSWORD=""
 
 function clear_extract_dir() {
-    rm -rf ${RESTORE_EXTRACT_DIR}
+    rm -rf "${RESTORE_EXTRACT_DIR}"
 }
 
 function restore_zip() {
@@ -20,9 +20,9 @@ function restore_zip() {
     local FIND_FILE_ATTACHMENTS
 
     if [[ -n "${ZIP_PASSWORD}" ]]; then
-        unzip -P ${ZIP_PASSWORD} ${RESTORE_FILE_ZIP} -d ${RESTORE_EXTRACT_DIR}
+        unzip -P "${ZIP_PASSWORD}" "${RESTORE_FILE_ZIP}" -d "${RESTORE_EXTRACT_DIR}"
     else
-        unzip ${RESTORE_FILE_ZIP} -d ${RESTORE_EXTRACT_DIR}
+        unzip "${RESTORE_FILE_ZIP}" -d "${RESTORE_EXTRACT_DIR}"
     fi
 
     if [[ $? == 0 ]]; then
@@ -34,21 +34,21 @@ function restore_zip() {
 
     # get restore db file
     RESTORE_FILE_DB=""
-    FIND_FILE_DB=$(basename $(ls ${RESTORE_EXTRACT_DIR}/db.*.sqlite3))
+    FIND_FILE_DB="$( basename "$(ls ${RESTORE_EXTRACT_DIR}/db.*.sqlite3)" )"
     if [[ -n "${FIND_FILE_DB}" ]]; then
         RESTORE_FILE_DB="extract/${FIND_FILE_DB}"
     fi
 
     # get restore config file
     RESTORE_FILE_CONFIG=""
-    FIND_FILE_CONFIG=$(basename $(ls ${RESTORE_EXTRACT_DIR}/config.*.json))
+    FIND_FILE_CONFIG="$( basename "$(ls ${RESTORE_EXTRACT_DIR}/config.*.json)" )"
     if [[ -n "${FIND_FILE_CONFIG}" ]]; then
         RESTORE_FILE_CONFIG="extract/${FIND_FILE_CONFIG}"
     fi
 
     # get restore attachments file
     RESTORE_FILE_ATTACHMENTS=""
-    FIND_FILE_ATTACHMENTS=$(basename $(ls ${RESTORE_EXTRACT_DIR}/attachments.*.tar))
+    FIND_FILE_ATTACHMENTS="$( basename "$(ls ${RESTORE_EXTRACT_DIR}/attachments.*.tar)" )"
     if [[ -n "${FIND_FILE_ATTACHMENTS}" ]]; then
         RESTORE_FILE_ATTACHMENTS="extract/${FIND_FILE_ATTACHMENTS}"
     fi
@@ -60,7 +60,7 @@ function restore_zip() {
 function restore_db() {
     color blue "restore bitwarden_rs sqlite database"
 
-    cp -f ${RESTORE_FILE_DB} ${DATA_DB}
+    cp -f "${RESTORE_FILE_DB}" "${DATA_DB}"
 
     if [[ $? == 0 ]]; then
         color green "restore bitwarden_rs sqlite database successful"
@@ -72,7 +72,7 @@ function restore_db() {
 function restore_config() {
     color blue "restore bitwarden_rs config"
 
-    cp -f ${RESTORE_FILE_CONFIG} ${DATA_CONFIG}
+    cp -f "${RESTORE_FILE_CONFIG}" "${DATA_CONFIG}"
 
     if [[ $? == 0 ]]; then
         color green "restore bitwarden_rs config successful"
@@ -84,8 +84,8 @@ function restore_config() {
 function restore_attachments() {
     color blue "restore bitwarden_rs attachments"
 
-    rm -rf ${DATA_ATTACHMENTS}
-    tar -x -C ${DATA_DIR} -f ${RESTORE_FILE_ATTACHMENTS}
+    rm -rf "${DATA_ATTACHMENTS}"
+    tar -x -C "${DATA_DIR}" -f "${RESTORE_FILE_ATTACHMENTS}"
 
     if [[ $? == 0 ]]; then
         color green "restore bitwarden_rs attachments successful"
@@ -103,7 +103,7 @@ function check_restore_file_exist() {
 
 function restore_file() {
     if [[ -n "${RESTORE_FILE_ZIP}" ]]; then
-        check_restore_file_exist ${RESTORE_FILE_ZIP} "--zip-file"
+        check_restore_file_exist "${RESTORE_FILE_ZIP}" "--zip-file"
 
         RESTORE_FILE_ZIP="${RESTORE_DIR}/${RESTORE_FILE_ZIP}"
 
@@ -112,19 +112,19 @@ function restore_file() {
         clear_extract_dir
     else
         if [[ -n "${RESTORE_FILE_DB}" ]]; then
-            check_restore_file_exist ${RESTORE_FILE_DB} "--db-file"
+            check_restore_file_exist "${RESTORE_FILE_DB}" "--db-file"
 
             RESTORE_FILE_DB="${RESTORE_DIR}/${RESTORE_FILE_DB}"
         fi
 
         if [[ -n "${RESTORE_FILE_CONFIG}" ]]; then
-            check_restore_file_exist ${RESTORE_FILE_CONFIG} "--config-file"
+            check_restore_file_exist "${RESTORE_FILE_CONFIG}" "--config-file"
 
             RESTORE_FILE_CONFIG="${RESTORE_DIR}/${RESTORE_FILE_CONFIG}"
         fi
 
         if [[ -n "${RESTORE_FILE_ATTACHMENTS}" ]]; then
-            check_restore_file_exist ${RESTORE_FILE_ATTACHMENTS} "--attachments-file"
+            check_restore_file_exist "${RESTORE_FILE_ATTACHMENTS}" "--attachments-file"
 
             RESTORE_FILE_ATTACHMENTS="${RESTORE_DIR}/${RESTORE_FILE_ATTACHMENTS}"
         fi
@@ -169,22 +169,22 @@ function restore() {
                 ;;
             --zip-file)
                 shift
-                RESTORE_FILE_ZIP=$(basename "$1")
+                RESTORE_FILE_ZIP="$(basename "$1")"
                 shift
                 ;;
             --db-file)
                 shift
-                RESTORE_FILE_DB=$(basename "$1")
+                RESTORE_FILE_DB="$(basename "$1")"
                 shift
                 ;;
             --config-file)
                 shift
-                RESTORE_FILE_CONFIG=$(basename "$1")
+                RESTORE_FILE_CONFIG="$(basename "$1")"
                 shift
                 ;;
             --attachments-file)
                 shift
-                RESTORE_FILE_ATTACHMENTS=$(basename "$1")
+                RESTORE_FILE_ATTACHMENTS="$(basename "$1")"
                 shift
                 ;;
             *)


### PR DESCRIPTION
Hey @ttionya,

so sorry for creating so many PRs lately.

Since we've introduced `BACKUP_FILE_DATE_SUFFIX` the user can create a backup file which may contain a space character. This will cause some issues because the scripts are not completely escaped.

In order to fix this and prevent further additions to break the current code I escaped every variable in all scripts. 
Furthermore I replaced the scripts with a bourne shell in order to use the bash arrays. We need bash arrays in order to delete backup files which contain a space character.

Again: I didn't test the changes, but I am confident that this won't break anything.