### PR TITLE
feat: replaced zip archive with more secure 7z archive

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,6 @@ LABEL "repository"="https://github.com/ttionya/BitwardenRS-Backup" \
 COPY scripts/*.sh /app/
 
 RUN chmod +x /app/*.sh \
-  && apk add --no-cache bash sqlite zip heirloom-mailx tzdata
+  && apk add --no-cache bash sqlite zip heirloom-mailx tzdata p7zip
 
 ENTRYPOINT ["/app/entrypoint.sh"]

--- a/scripts/backup.sh
+++ b/scripts/backup.sh
@@ -15,7 +15,7 @@ function backup_init() {
     # backup bitwarden_rs attachments directory
     BACKUP_FILE_ATTACHMENTS="${BACKUP_DIR}/attachments.${NOW}.tar"
     # backup zip file
-    BACKUP_FILE_ZIP="${BACKUP_DIR}/backup.${NOW}.zip"
+    BACKUP_FILE_ZIP="${BACKUP_DIR}/backup.${NOW}.7z"
 }
 
 function backup_db() {
@@ -66,17 +66,16 @@ function backup() {
 
 function backup_package() {
     if [[ "${ZIP_ENABLE}" == "TRUE" ]]; then
+        color blue "display backup zip file list"
+        
+        ls -lah "${BACKUP_DIR}"
+
         color blue "package backup file"
 
         UPLOAD_FILE="${BACKUP_FILE_ZIP}"
+        # explanation for this 7z command: https://askubuntu.com/a/928301
+        7z a -t7z -m0=lzma2 -mx=9 -mfb=64 -md=32m -ms=on -mhe=on -p"${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}"
 
-        zip -jP "${ZIP_PASSWORD}" "${BACKUP_FILE_ZIP}" "${BACKUP_DIR}"/*
-
-        ls -lah "${BACKUP_DIR}"
-
-        color blue "display backup zip file list"
-
-        zip -sf "${BACKUP_FILE_ZIP}"
     else
         color yellow "skip package backup files"
 

--- a/scripts/restore.sh
+++ b/scripts/restore.sh
@@ -20,9 +20,9 @@ function restore_zip() {
     local FIND_FILE_ATTACHMENTS
 
     if [[ -n "${ZIP_PASSWORD}" ]]; then
-        unzip -P "${ZIP_PASSWORD}" "${RESTORE_FILE_ZIP}" -d "${RESTORE_EXTRACT_DIR}"
+	    7za e -p"${ZIP_PASSWORD}" -o"${RESTORE_EXTRACT_DIR}" "${RESTORE_FILE_ZIP}"
     else
-        unzip "${RESTORE_FILE_ZIP}" -d "${RESTORE_EXTRACT_DIR}"
+	    7za e -o"${RESTORE_EXTRACT_DIR}" "${RESTORE_FILE_ZIP}"
     fi
 
     if [[ $? == 0 ]]; then


### PR DESCRIPTION
hey @ttionya,

I replaced the zip archive with the more secure 7z archive. This is a breaking change and will cause all previously generated backups to be obsolete.
In order to keep the PR small I only replaced the internal archive / unarchive calls. 

If you want we can replace all the environment variables or the variables within the scripts I/we can do that.

What do you think of this change? I felt it is necessary since the password secured zip files are not secure at all.. 